### PR TITLE
Dockerfile: Update php to 7.4.7-fpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.6-fpm
+FROM php:7.4.7-fpm
 
 RUN apt-get update && apt-get install -y libicu-dev \
 		libpq-dev \


### PR DESCRIPTION

Image **php** updated from 7.4.6-fpm to 7.4.7-fpm

**Image:** [php](https://hub.docker.com/r/library/php/)  
**Version:** 7.4.6-fpm &rarr; 7.4.7-fpm  
**Dockerfile:** Dockerfile  


If you need help or something went wrong, please comment here while mentioning me (@DockerUpBot) or use the [support formular](https://dockerup.net/support?repo=c3ca2ef2-c49c-4fea-b96b-6e251a5a72d8).

<hr>
<p align="center">
  <a href="https://dockerup.net"><img align="center" src="https://dockerup.net/img/logo.svg" alt="Docker Up" width="200px"></a>
<br>
Automated <b>Dockerfile</b> updates
</p>
	